### PR TITLE
Fix get_sql_field_type method

### DIFF
--- a/lib/mini_record/auto_schema.rb
+++ b/lib/mini_record/auto_schema.rb
@@ -52,11 +52,9 @@ module MiniRecord
       end
 
       def get_sql_field_type(field)
-        if field.respond_to?(:sql_type)
-          # Rails 3.2 and earlier
+        if ActiveRecord::VERSION::MAJOR.to_i < 4
           field.sql_type.to_s.downcase
         else
-          # Rails 4
           connection.type_to_sql(field.type.to_sym, field.limit, field.precision, field.scale)
         end
       end


### PR DESCRIPTION
`sql_type` method is resurrected from AR 4.1.2.
https://github.com/rails/rails/blob/v4.1.2/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L18
