### PR TITLE
Remove duplicate field type changes, add support for custom index names

### DIFF
--- a/lib/mini_record/auto_schema.rb
+++ b/lib/mini_record/auto_schema.rb
@@ -331,14 +331,16 @@ module MiniRecord
           remove_foreign_keys if connection.respond_to?(:foreign_keys)
 
           # Remove old index
-          (indexes_in_db.keys - indexes.keys).each do |name|
+          index_names = indexes.collect{|name,opts| opts[:name] || name }
+          (indexes_in_db.keys - index_names).each do |name|
             connection.remove_index(table_name, :name => name)
           end
 
           # Add indexes
           indexes.each do |name, options|
             options = options.dup
-            unless connection.indexes(table_name).detect { |i| i.name == name }
+            index_name = options[:name] || name
+            unless connection.indexes(table_name).detect { |i| i.name == index_name }
               connection.add_index(table_name, options.delete(:column), options)
             end
           end


### PR DESCRIPTION
Hi David, this changeset removes the duplicate field type checks that are already handled by comparing the field options below.  It also adds support for custom index names which have never been supported properly.  I've tested this with a Rails 4 app and it seems to work properly.  I have not tried backporting to Rails 3.2.

Thanks,
Nate
