### PR TITLE
Fix :default handling for Rails 4.2 and update tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,16 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in mini_record.gemspec
 gem 'rake'
 gem 'minitest'
+
+# Test database version with rake test DB=mysql2
 gem 'sqlite3'
-gem 'mysql2'
-gem 'mysql'
 gem 'pg'
-gem 'activerecord', '<= 3.2'
+gem 'mysql'
+gem 'mysql2'
+
+# Uncomment to test older versions, then re-bundle
+# gem 'activerecord', '<= 3.2'
+gem 'activerecord', '>= 4.2'
 
 group :test do
   gem 'foreigner', '>= 1.4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,17 @@ source "http://rubygems.org"
 gem 'rake'
 gem 'minitest'
 
-# Test database version with rake test DB=mysql2
+# Test database adapters with "rake test DB=mysql2"
 gem 'sqlite3'
 gem 'pg'
 gem 'mysql'
 gem 'mysql2'
 
-# Uncomment to test older versions, then re-bundle
+# Uncomment to test older versions, then "bundle update"
 # gem 'activerecord', '<= 3.2'
-gem 'activerecord', '>= 4.2'
+# gem 'activerecord', '~> 4.0.0'
+# gem 'activerecord', '~> 4.1.0'
+gem 'activerecord', '>= 4.2.0'
 
 group :test do
   gem 'foreigner', '>= 1.4.2'

--- a/lib/mini_record/auto_schema.rb
+++ b/lib/mini_record/auto_schema.rb
@@ -224,6 +224,51 @@ module MiniRecord
         end
       end
 
+      # Helper to determine if/how a field will change
+      def field_attr_changes(field_name)
+        field    = field_name.to_s
+        changed  = false  # flag
+        new_attr = {}
+
+        # Next, iterate through our extended attributes, looking for any differences
+        # This catches stuff like :null, :precision, etc
+        # Ignore junk attributes that different versions of Rails include
+        [:name, :limit, :precision, :scale, :default, :null].each do |att|
+          value = fields[field][att]
+          value = true if att == :null && value.nil?
+
+          # Skip unspecified limit/precision/scale as DB will set them to defaults,
+          # and on subsequent runs, this will be erroneously detected as a change.
+          next if value.nil? and [:limit, :precision, :scale].include?(att)
+
+          old_value = fields_in_db[field].send(att)
+          # puts "#{field_name}[#{att}] = #{value.inspect} vs #{old_value.inspect}"
+
+          attr_changed = false
+          if att == :default
+            # Rails 4.2 changed behavior to pass DB values directly through, so we must re-map
+            if value.to_s =~ /^(false|f|0)$/i
+              attr_changed = true if old_value.to_s !~ /^(false|f|0)$/i
+            elsif value.to_s =~ /^(true|t|1)$/i
+              attr_changed = true if old_value.to_s !~ /^(true|t|1)$/i
+            elsif value.to_s != old_value.to_s
+              attr_changed = true
+            end
+          elsif value != old_value
+            attr_changed = true
+          end
+
+          if attr_changed
+            logger.debug "[MiniRecord] Detected schema change for #{table_name}.#{field}##{att} " +
+                         "from #{old_value.inspect} to #{value.inspect}" if logger
+            new_attr[att] = value
+            changed ||= attr_changed
+          end
+        end
+
+        [new_attr, changed]
+      end
+
       # dry-run
       def auto_upgrade_dry
         auto_upgrade!(true)
@@ -322,36 +367,7 @@ module MiniRecord
             # Change attributes of existent columns
             (fields.keys & fields_in_db.keys).each do |field|
               if field != primary_key #ActiveRecord::Base.get_primary_key(table_name)
-                changed  = false  # flag
-                new_attr = {}
-
-                # Special catch for precision/scale, since *both* must be specified together
-                # Always include them in the attr struct, but they'll only get applied if changed = true
-                new_attr[:precision] = fields[field][:precision]
-                new_attr[:scale]     = fields[field][:scale]
-
-                # If we have precision this is also the limit
-                fields[field][:limit] ||= fields[field][:precision]
-
-                # Next, iterate through our extended attributes, looking for any differences
-                # This catches stuff like :null, :precision, etc
-                # Ignore junk attributes that different versions of Rails include
-                [:name, :limit, :precision, :scale, :default, :null].each do |att|
-                  value = fields[field][att]
-                  value = true if att == :null && value.nil?
-
-                  # Skip unspecified limit/precision/scale as DB will set them to defaults,
-                  # and on subsequent runs, this will be erroneously detected as a change.
-                  next if value.nil? and [:limit, :precision, :scale].include?(att)
-
-                  old_value = fields_in_db[field].send(att)
-                  if value.to_s != old_value.to_s
-                    logger.debug "[MiniRecord] Detected schema change for #{table_name}.#{field}##{att} " +
-                                 "from #{old_value.inspect} to #{value.inspect}" if logger
-                    new_attr[att] = value
-                    changed = true
-                  end
-                end
+                new_attr, changed = field_attr_changes(field)
 
                 # Change the column if applicable
                 new_type = fields[field].type.to_sym

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,24 +39,25 @@ class ActiveRecord::Base
 
     def auto_upgrade!(*args)
       ActiveRecord::Base.logs = StringIO.new
-      ActiveRecord::Base.logger = ActiveSupport::BufferedLogger.new(ActiveRecord::Base.logs)
+      ActiveRecord::Base.logger = Logger.new(ActiveRecord::Base.logs)
       silence_stream(STDERR) { super }
     end
 
     def auto_upgrade_dry
       ActiveRecord::Base.logs = StringIO.new
-      ActiveRecord::Base.logger = ActiveSupport::BufferedLogger.new(ActiveRecord::Base.logs)
+      ActiveRecord::Base.logger = Logger.new(ActiveRecord::Base.logs)
       silence_stream(STDERR) { super }
     end
   end
 end # ActiveRecord::Base
 
-# Setup Adatper
+# Setup Adapter
+puts "Testing with DB=#{ENV['DB'] || 'sqlite'}"
 case ENV['DB']
 when 'mysql'
-  ActiveRecord::Base.establish_connection(:adapter => 'mysql', :database => 'test', :user => 'root')
+  ActiveRecord::Base.establish_connection(:adapter => 'mysql', :database => 'test', :username => 'root')
 when 'mysql2'
-  ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'test', :user => 'root')
+  ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'test', :username => 'root')
   Bundler.require(:test)  # require 'foreigner'
   Foreigner.load
 when 'pg', 'postgresql'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
+require 'logger'
 require 'mini_record'
 require 'minitest/autorun'
 

--- a/test/test_mini_record.rb
+++ b/test/test_mini_record.rb
@@ -141,7 +141,7 @@ describe MiniRecord do
     assert_includes Foo.db_indexes, 'by_customer'
     # Run auto_upgrade! again and ensure no statements issued.
     Foo.auto_upgrade!
-    assert_empty Foo.queries
+    refute_match /schema\s+change/, Foo.queries
   end
 
   it 'does not add already defined composite indexes' do
@@ -156,7 +156,7 @@ describe MiniRecord do
     assert_includes Foo.db_indexes, 'by_region_and_customer'
     # Run auto_upgrade! again and ensure no statements issued.
     Foo.auto_upgrade!
-    assert_empty Foo.queries
+    refute_match /schema\s+change/, Foo.queries
   end
 
   it 'supports indexes with symbols for names' do
@@ -169,7 +169,7 @@ describe MiniRecord do
     assert_includes Foo.db_indexes, 'idx_for_some_field'
     # Run auto_upgrade! again and ensure no statements issued.
     Foo.auto_upgrade!
-    assert_empty Foo.queries
+    refute_match /schema\s+change/, Foo.queries
   end
 
   it 'works with STI' do
@@ -244,7 +244,7 @@ describe MiniRecord do
   end
 
   it 'allow custom query' do
-    skip unless conn.adapter_name =~ /mysql/i
+    skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
     class Foo < ActiveRecord::Base
       col :name, :as => "ENUM('foo','bar')"
@@ -253,7 +253,7 @@ describe MiniRecord do
     assert_match /ENUM/, Foo.queries
 
     Foo.auto_upgrade!
-    assert_empty Foo.queries
+    refute_match /schema\s+change/, Foo.queries
     assert_equal %w[id name], Foo.db_columns
     assert_equal %w[id name], Foo.schema_columns
 
@@ -282,6 +282,8 @@ describe MiniRecord do
     end
 
     it 'removes a column and index when relation is removed' do
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       class Foo < ActiveRecord::Base
         key :name
         belongs_to :image, :polymorphic => true
@@ -397,17 +399,17 @@ describe MiniRecord do
 
     it 'should not override previous defined column relation' do
       class Foo < ActiveRecord::Base
-        key :user_id, :as => :references, :null => false, :limit => 4, :default => 42
+        key :user, :as => :references, :null => false, :limit => 4, :default => 42
         belongs_to :user
       end
       Foo.auto_upgrade!
       assert_equal 4, Foo.db_fields[:user_id].limit
       assert_equal false, Foo.db_fields[:user_id].null
-      assert_equal "42", Foo.db_fields[:user_id].default
+      assert_equal "42", Foo.db_fields[:user_id].default.to_s
     end
 
     it 'add/remove foreign key with :foreign option, when Foreigner gem used on mysql' do
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :publisher
@@ -432,7 +434,7 @@ describe MiniRecord do
 
     it 'doesnt remove foreign key with :foreign option, when Foreigner gem used on mysql and destructive = false' do
       MiniRecord.configuration.destructive = false
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :publisher
@@ -457,7 +459,7 @@ describe MiniRecord do
     end
 
     it 'add/remove named foreign key with :foreign option, when Foreigner gem used on mysql' do
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :publisher
@@ -483,7 +485,7 @@ describe MiniRecord do
 
     it 'doesnt remove named foreign key with :foreign option, when Foreigner gem used on mysql and destructive = false' do
       MiniRecord.configuration.destructive = false
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :publisher
@@ -509,7 +511,7 @@ describe MiniRecord do
     end
 
     it 'support :foreign option in the index with custom :foreign_key in the belong_to association' do
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :second_publisher, :foreign_key => 'second_publisher_id', :class_name => 'Publisher'
@@ -534,7 +536,7 @@ describe MiniRecord do
 
     it 'support :foreign option in the index with custom :foreign_key in the belong_to association and wont remove if destructive = false' do
       MiniRecord.configuration.destructive = false
-      skip unless conn.adapter_name =~ /mysql/i
+      skip "foreign key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       class Book < ActiveRecord::Base
         belongs_to :second_publisher, :foreign_key => 'second_publisher_id', :class_name => 'Publisher'
@@ -580,6 +582,8 @@ describe MiniRecord do
 
   describe 'relation #habtm' do
     it 'creates a join table with indexes for has_and_belongs_to_many relations' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       tables = Tool.connection.tables
       assert_includes tables, 'purposes_tools'
 
@@ -593,6 +597,8 @@ describe MiniRecord do
     end
 
     it 'drops join table if has_and_belongs_to_many relation is deleted' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       Tool.schema_tables.delete('purposes_tools')
       refute_includes ActiveRecord::Base.schema_tables, 'purposes_tools'
 
@@ -602,6 +608,7 @@ describe MiniRecord do
 
     it 'keeps join table if has_and_belongs_to_many relation is deleted and destructive = false' do
       MiniRecord.configuration.destructive = false
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
 
       tables = Tool.connection.tables
       assert_includes tables, 'purposes_tools'
@@ -614,6 +621,8 @@ describe MiniRecord do
     end
 
     it 'has_and_belongs_to_many with custom join_table and foreign keys' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       class Foo < ActiveRecord::Base
         has_and_belongs_to_many :watchers, :join_table => :watching, :foreign_key => :custom_foo_id, :association_foreign_key => :customer_id
       end
@@ -627,6 +636,8 @@ describe MiniRecord do
     end
 
     it 'creates a join table with indexes with long indexes names' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       class Foo < ActiveRecord::Base
         has_and_belongs_to_many :people,   :join_table  => :long_people,
                                            :foreign_key => :custom_long_long_long_long_id,
@@ -639,6 +650,8 @@ describe MiniRecord do
     end
 
     it 'creates a join table without an index when suppressed for has_and_belongs_to_many relations' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       class Foo < ActiveRecord::Base
         has_and_belongs_to_many :bars
         suppress_index :bars
@@ -649,6 +662,8 @@ describe MiniRecord do
     end
 
     it 'adds unique index' do
+      skip "habtm key tests only for mysql" unless conn.adapter_name =~ /mysql/i
+
       page = Page.create(:title => 'Foo')
       photogallery = Photogallery.create(:title => 'Bar')
       assert photogallery.valid?
@@ -699,19 +714,19 @@ describe MiniRecord do
     case conn.adapter_name
     when /sqlite/i
       # In sqlite there is a difference between limit: 4 and limit: 11
-      assert_match 'altered', Foo.queries
-      assert_equal 4, Foo.db_fields[:number].limit
+      assert_match 'foos.number#limit', Foo.queries
       assert_equal 4, Foo.schema_fields[:number].limit
+      assert_equal 4, Foo.db_fields[:number].limit
     when /mysql/i
       # In mysql according to this: http://goo.gl/bjZE7 limit: 4 is same of limit:11
-      assert_empty Foo.queries
-      assert_equal 4, Foo.db_fields[:number].limit
+      refute_match /schema\s+change/, Foo.queries
       assert_equal 4, Foo.schema_fields[:number].limit
+      assert_equal 4, Foo.db_fields[:number].limit
     when /postgres/i
       # In postgres limit: 4 will be translated to nil
       assert_match /ALTER COLUMN "number" TYPE integer$/, Foo.queries
-      assert_equal nil, Foo.db_fields[:number].limit
       assert_equal   4, Foo.schema_fields[:number].limit
+      assert_equal nil, Foo.db_fields[:number].limit
     end
 
     # Change limit to string
@@ -745,7 +760,7 @@ describe MiniRecord do
       assert_equal 4, Foo.schema_fields[:number].limit
     when /mysql/i
       # In mysql according to this: http://goo.gl/bjZE7 limit: 4 is same of limit:11
-      assert_empty Foo.queries
+      refute_match /schema\s+change/, Foo.queries
       assert_equal nil, Foo.db_fields[:number].limit
       assert_equal 4, Foo.schema_fields[:number].limit
     when /postgres/i
@@ -758,19 +773,40 @@ describe MiniRecord do
     # Change limit to string
     Foo.key :string, :limit => 255
     Foo.auto_upgrade!
-    assert_empty Foo.queries
+    refute_match /schema\s+change/, Foo.queries
     assert_equal 100, Foo.db_fields[:string].limit
   end
 
   it 'should handle integer defaults correctly' do
     class Foo < ActiveRecord::Base
-      field :some_int, type: :integer, default: 1
-      field :some_bool, type: :boolean, default: 0
+      field :some_int, type: :integer, default: 33
+      field :some_bool, type: :boolean, default: false
+      field :some_bool2, type: :boolean, default: false
+      field :some_bool3, type: :boolean, default: true
+      auto_upgrade!
     end
-    # Run auto_upgrade! once to create table and index.
-    Foo.auto_upgrade!
-    assert_equal "1", Foo.db_fields[:some_int].default
-    assert_equal "0", Foo.db_fields[:some_bool].default
+
+    # Reopen class
+    class Foo < ActiveRecord::Base
+      field :some_int, type: :integer, default: 66
+      field :some_bool, type: :boolean, default: true
+    end
+
+    new_attr, changed = Foo.field_attr_changes(:some_int)
+    assert_equal 66, new_attr[:default]
+    assert_equal true, changed
+
+    new_attr, changed = Foo.field_attr_changes(:some_bool)
+    assert_equal true, changed
+    assert_equal true, new_attr[:default]
+
+    new_attr, changed = Foo.field_attr_changes(:some_bool2)
+    assert_equal false, changed
+    assert_empty new_attr
+
+    new_attr, changed = Foo.field_attr_changes(:some_bool3)
+    assert_equal false, changed
+    assert_empty new_attr
   end
 
   it 'should change #null' do
@@ -793,7 +829,7 @@ describe MiniRecord do
 
     Foo.key :string, :null => false
     Foo.auto_upgrade!
-    assert_match /alter/i, Foo.queries
+    assert_match /foos.string#null/i, Foo.queries
     refute Foo.db_fields[:string].null
   end
 
@@ -829,17 +865,16 @@ describe MiniRecord do
     Foo.auto_upgrade!
     assert_equal 8, Foo.db_fields[:currency].precision
     assert_equal 2, Foo.db_fields[:currency].scale
-    assert_equal 8, Foo.db_fields[:currency].limit
 
     Foo.auto_upgrade!
-    refute_match /alter/i, Foo.queries
+    new_attr, changed = Foo.field_attr_changes(:currency)
+    assert_equal false, changed
 
     Foo.field :currency, :as => :decimal, :precision => 4, :scale => 2, :limit => 5
     Foo.auto_upgrade!
-    assert_match /alter/i, Foo.queries
+    assert_match /foos.currency#limit/i, Foo.queries
     assert_equal 4, Foo.db_fields[:currency].precision
     assert_equal 2, Foo.db_fields[:currency].scale
-    assert_equal 4, Foo.db_fields[:currency].limit
   end
 
   it 'should not change #scale #precision if destructive = false' do
@@ -850,7 +885,6 @@ describe MiniRecord do
     Foo.auto_upgrade!
     assert_equal 8, Foo.db_fields[:currency].precision
     assert_equal 2, Foo.db_fields[:currency].scale
-    assert_equal 8, Foo.db_fields[:currency].limit
 
     Foo.auto_upgrade!
     refute_match /alter/i, Foo.queries
@@ -860,7 +894,6 @@ describe MiniRecord do
     assert_match "", Foo.queries
     assert_equal 8, Foo.db_fields[:currency].precision
     assert_equal 2, Foo.db_fields[:currency].scale
-    assert_equal 8, Foo.db_fields[:currency].limit
   end
 
   it 'should ignore abstract classes' do
@@ -917,14 +950,7 @@ describe MiniRecord do
 
     Foo.auto_upgrade!
 
-    case conn.adapter_name
-    when /sqlite/i
-      assert_match /CREATE TEMPORARY TABLE "altered_foos"/i, Foo.queries
-    when /mysql/i
-      assert_match /ALTER TABLE `foos` CHANGE `currency` `currency_iso`/i, Foo.queries
-    when /postgres/i
-      assert_match /ALTER TABLE "foos" RENAME COLUMN "currency" TO "currency_iso"/, Foo.queries
-    end
+    assert_match /foos.currency to currency_iso/i, Foo.queries
 
     foo = Foo.first
     assert_equal 'USD', foo.currency_iso


### PR DESCRIPTION
Hi Davide - here are some updates for Rails 4.2 that fix the handling of `:default`.  I also updated the tests to pass across multiple versions of Rails.  Cheers!