### PR TITLE
Do not add limit option for postgres range columns

### DIFF
--- a/lib/mini_record/auto_schema.rb
+++ b/lib/mini_record/auto_schema.rb
@@ -114,7 +114,8 @@ module MiniRecord
           #   t.column :type, "ENUM('EMPLOYEE','CLIENT','SUPERUSER','DEVELOPER')"
           if type.is_a?(String)
             # will be converted in: t.column :type, "ENUM('EMPLOYEE','CLIENT')"
-            table_definition.column(column_name, type, options.reverse_merge(:limit => 0))
+            options.reverse_merge!(:limit => 0) unless postgresql_range?(type)
+            table_definition.column(column_name, type, options)
           else
             # wil be converted in: t.string :name
             table_definition.send(type, column_name, options)
@@ -137,6 +138,11 @@ module MiniRecord
       alias :key       :field
       alias :property  :field
       alias :col       :field
+
+      def postgresql_range? type
+        return unless connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+        type =~ /range/
+      end
 
       def timestamps
         field :created_at, :updated_at, :as => :datetime


### PR DESCRIPTION
When using any postgres range column it tries to create a column like this:
```sql
ALTER TABLE "x" ADD "y" numrange(0)
```

`(0)` is added because of `:limit` option.
with this path the `:limit` option wont be added if column type contains `range` and connection type is postgres.
