### PR TITLE
Delete `:foreign` option when adding indexes

### DIFF
--- a/lib/mini_record/auto_schema.rb
+++ b/lib/mini_record/auto_schema.rb
@@ -418,6 +418,7 @@ module MiniRecord
           # Add indexes
           indexes.each do |name, options|
             options = options.dup
+            options.delete(:foreign)
             adjusted_index_name = "index_#{table_name}_on_" + (options[:column].is_a?(Array) ? options[:column].join('_and_') : options[:column]).to_s
             index_name = (options[:name] || adjusted_index_name).to_s
             unless connection.indexes(table_name).detect { |i| i.name == index_name }


### PR DESCRIPTION
Otherwise ActiveRecord raises a `ArgumentError`:

```
ArgumentError: Unknown key: :foreign. Valid keys are: :unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type
activesupport-4.2.5/lib/active_support/core_ext/hash/keys.rb:75:in `block in assert_valid_keys'
activesupport-4.2.5/lib/active_support/core_ext/hash/keys.rb:73:in `each_key'
activesupport-4.2.5/lib/active_support/core_ext/hash/keys.rb:73:in `assert_valid_keys'
activerecord-4.2.5/lib/active_record/connection_adapters/abstract/schema_statements.rb:916:in `add_index_options'
activerecord-4.2.5/lib/active_record/connection_adapters/postgresql/schema_statements.rb:476:in `add_index'
mini_record-0.4.6/lib/mini_record/auto_schema.rb:418:in `block in auto_upgrade!'
mini_record-0.4.6/lib/mini_record/auto_schema.rb:412:in `each'
mini_record-0.4.6/lib/mini_record/auto_schema.rb:412:in `auto_upgrade!'
```

```
$ ruby -v
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]
```
